### PR TITLE
Github traffic statistics to badge

### DIFF
--- a/.github/workflows/traffic2badge.yml
+++ b/.github/workflows/traffic2badge.yml
@@ -1,0 +1,61 @@
+name: traffic2badge
+on:
+  push:
+    branches:
+      - master
+  schedule:
+    - cron: '1 0 * * *' #every day at 00:01:00 UTC
+
+jobs:
+  run:
+    name: Make GitHub Traffic to Badge
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2.3.3
+
+      - name: Get Commit Message
+        id: message
+        uses: actions/github-script@v3.0.0
+        env:
+          FULL_COMMIT_MESSAGE: '${{ github.event.head_commit.message }}'
+        with:
+          result-encoding: string
+          script: |
+            var message = `${process.env.FULL_COMMIT_MESSAGE}`;
+            core.info(message);
+            if (message != '') return message;
+            var time = new Date(Date.now()).toISOString();
+            core.info(time);
+            return `Get traffic data at ${time}`;
+
+      - name: Set Traffic
+        id: traffic
+        uses: yi-Xu-0100/traffic-to-badge@v1.2.1
+        with:
+          my_token: ${{ secrets.TRAFFIC_TOKEN }}
+          #(default) static_list: ${{ github.repository }}
+          #(default) traffic_branch: traffic
+          #(default) views_color: brightgreen
+          #(default) clones_color: brightgreen
+          #(default) views_week_color: brightgreen
+          #(default) clones_week_color: brightgreen
+          #(default) logo: github
+          #(default) year:
+
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3.7.3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_branch: ${{ steps.traffic.outputs.traffic_branch }}
+          publish_dir: ${{ steps.traffic.outputs.traffic_path }}
+          user_name: 'github-actions[bot]'
+          user_email: 'github-actions[bot]@users.noreply.github.com'
+          full_commit_message: ${{ steps.message.outputs.result }}
+
+      - name: Show Traffic Data
+        run: |
+          echo ${{ steps.traffic.outputs.traffic_branch }}
+          echo ${{ steps.traffic.outputs.traffic_path }}
+          cd ${{ steps.traffic.outputs.traffic_path }}
+          ls -a

--- a/README.md
+++ b/README.md
@@ -3,6 +3,12 @@
 ![Free](https://img.shields.io/badge/free-open--source-green.svg)
 [![MIT License](http://img.shields.io/badge/license-MIT-green.svg)](https://github.com/yashaka/nselene/blob/master/LICENSE)
 
+![GitHub stats in](https://raw.githubusercontent.com/yashaka/NSelene/traffic/traffic-selene/in_2021.svg)
+![GitHub views](https://raw.githubusercontent.com/yashaka/NSelene/traffic/traffic-selene/views.svg)
+![GitHub views per week](https://raw.githubusercontent.com/yashaka/NSelene/traffic/traffic-selene/views_per_week.svg)
+![GitHub clones](https://raw.githubusercontent.com/yashaka/NSelene/traffic/traffic-selene/clones.svg)
+![GitHub clones per week](https://raw.githubusercontent.com/yashaka/NSelene/traffic/traffic-selene/clones_per_week.svg)
+
 [![Join telegram chat https://t.me/nselene](https://img.shields.io/badge/chat-telegram-blue)](https://t.me/nselene)
 [![Присоединяйся к чату https://t.me/nselene_ru](https://img.shields.io/badge/%D1%87%D0%B0%D1%82-telegram-red)](https://t.me/nselene_ru)
 


### PR DESCRIPTION
### ToDo
1. create PAT with repo: access for cron job in User->Settings->Developer settings.
2.  add PAT to Repository -> Settings -> Secrets variables as TRAFFIC_TOKEN.

### Result
Readme will have these badges
![image](https://user-images.githubusercontent.com/17043964/103806513-37eb8400-5066-11eb-821b-1a8706f4163c.png)

