### PR TITLE
#90: refactored collection index to not use Should(Have.Count(...)

### DIFF
--- a/NSelene/SeleneLocator.cs
+++ b/NSelene/SeleneLocator.cs
@@ -107,7 +107,16 @@ namespace NSelene
 
         public override IWebElement Find ()
         {
-            return this.context.Should(Have.CountAtLeast(this.index+1)).ActualWebElements[index];
+            var actualWebElements = this.context.ActualWebElements;
+            if (actualWebElements.Count <= this.index)
+            {
+                throw new NotFoundException(
+                    $"element was not found in collection by index {this.index} " +
+                    $"(actual collection size is {actualWebElements.Count})"
+                );
+            }
+
+            return actualWebElements[this.index];
         }
     }
 

--- a/NSeleneTests/Integration/SharedDriver/ErrorMessages_Specs.cs
+++ b/NSeleneTests/Integration/SharedDriver/ErrorMessages_Specs.cs
@@ -1,15 +1,11 @@
-using NSelene;
 using static NSelene.Selene;
 using NUnit.Framework;
-using OpenQA.Selenium;
 using NSelene.Support.SeleneElementJsExtensions;
+using NSelene.Tests.Integration.SharedDriver.Harness;
+using System;
 
 namespace NSelene.Tests.Integration.SharedDriver
 {
-    using System;
-    using System.Linq;
-    using Harness;
-
     [TestFixture]
     public class ErrorMessages_Specs : BaseTest
     {


### PR DESCRIPTION
Refactor the index method in the Collection. Now it will only timeout in case of real failure, see added testcase.

Not fully sure about the error message, see below:
```
Timed out after 0,25s, while waiting for:
    Browser.All(#will-not-appear)[100].Should(Be.InDom)
Reason:
    element was not found in collection by index 100 (actual collection size is 0)
```